### PR TITLE
Deprecate getAccountBalance

### DIFF
--- a/apply-interest.js
+++ b/apply-interest.js
@@ -1,5 +1,5 @@
 const api = require('@actual-app/api');
-const { closeBudget, ensurePayee, getAccountBalance, getAccountNote, getLastTransactionDate, openBudget, showPercent } = require('./utils');
+const { closeBudget, ensurePayee, getAccountNote, getLastTransactionDate, openBudget, showPercent } = require('./utils');
 require("dotenv").config();
 
 (async () => {
@@ -35,7 +35,7 @@ require("dotenv").config();
         if (!lastDate) continue;
         const daysPassed = Math.floor((interestTransactionDate - new Date(lastDate)) / 86400000);
 
-        const balance = await getAccountBalance(account, interestTransactionDate);
+        const balance = await api.getAccountBalance(account, interestTransactionDate);
         const compoundedInterest = Math.round(balance * (Math.pow(1 + interestRate / 12, 1) - 1));
 
         interestRate = showPercent(interestRate);

--- a/kbb.js
+++ b/kbb.js
@@ -1,6 +1,6 @@
 const api = require('@actual-app/api');
 const jsdom = require("jsdom");
-const { closeBudget, ensurePayee, getAccountBalance, getAccountNote, getLastTransactionDate, getTagValue, openBudget, setAccountNote, sleep } = require('./utils');
+const { closeBudget, ensurePayee, getAccountNote, getLastTransactionDate, getTagValue, openBudget, setAccountNote, sleep } = require('./utils');
 require("dotenv").config();
 
 async function getKBB(URL) {
@@ -52,7 +52,7 @@ async function getKBB(URL) {
         console.log('Fetching KBB for account:', account.name);
 
         const kbb = await getKBB(URL);
-        const balance = await getAccountBalance(account);
+        const balance = await api.getAccountBalance(account);
         const diff = kbb - balance;
 
         console.log('KBB:', kbb);

--- a/sync-bitcoin.js
+++ b/sync-bitcoin.js
@@ -1,4 +1,4 @@
-const { closeBudget, openBudget, getTransactions, getAccountNote, getAccountBalance, ensurePayee } = require('./utils');
+const { closeBudget, openBudget, getTransactions, getAccountNote, ensurePayee } = require('./utils');
 const api = require('@actual-app/api');
 
 function getValueAtPath(obj, path) {
@@ -53,7 +53,7 @@ async function getBitcoinPrice() {
       continue;
     }
     const btc_amount = note.split('BTC:')[1].split(' ')[0];
-    const currentBalance = await getAccountBalance(account);
+    const currentBalance = await api.getAccountBalance(account);
     const targetBalance = Math.round(bitcoinPrice * btc_amount * 100);
     const diff = currentBalance - targetBalance;
     if (diff != 0) {

--- a/track-investments.js
+++ b/track-investments.js
@@ -1,7 +1,7 @@
 const api = require('@actual-app/api');
 const fs = require('fs');
 const readline = require('readline-sync');
-const { closeBudget, ensureCategory, ensureCategoryGroup, ensurePayee, getAccountBalance, getAccountNote, getSimpleFinID, getTransactions, openBudget } = require('./utils');
+const { closeBudget, ensureCategory, ensureCategoryGroup, ensurePayee, getAccountNote, getSimpleFinID, getTransactions, openBudget } = require('./utils');
 require("dotenv").config();
 
 
@@ -112,7 +112,7 @@ const zeroTransaction = async (payment) => {
         }
 
         if (note.indexOf('calcInvestment') > -1) {
-          const currentBalance = await getAccountBalance(account);
+          const currentBalance = await api.getAccountBalance(account);
           const simpleFinID = await getSimpleFinID(account);
           const simplefinBalance = parseInt(simplefinBalances[simpleFinID] * 100);
           const diff = simplefinBalance - currentBalance;

--- a/utils.js
+++ b/utils.js
@@ -41,19 +41,6 @@ const Utils = {
     }
   },
 
-  getAccountBalance: async function (account, cutoffDate=new Date()) {
-    const data = await api.runQuery(
-      api.q('transactions')
-      .filter({
-        'account': account.id,
-        'date': { $lt: cutoffDate },
-      })
-      .calculate({ $sum: '$amount' })
-      .options({ splits: 'grouped' })
-    );
-    return data.data;
-  },
-
   getTransactions: async function (account) {
     const data = await api.runQuery(
       api.q('transactions')

--- a/zestimate.js
+++ b/zestimate.js
@@ -1,6 +1,6 @@
 const api = require('@actual-app/api');
 const jsdom = require("jsdom");
-const { closeBudget, ensurePayee, getAccountBalance, getAccountNote, openBudget, showPercent, sleep } = require('./utils');
+const { closeBudget, ensurePayee, getAccountNote, openBudget, showPercent, sleep } = require('./utils');
 require("dotenv").config();
 
 async function getZestimate(URL) {
@@ -59,7 +59,7 @@ async function getZestimate(URL) {
           console.log('Was unable to get Zestimate, skipping');
           continue;
       }
-      const balance = await getAccountBalance(account);
+      const balance = await api.getAccountBalance(account);
       const diff = (zestimate * ownership) - balance;
 
       console.log('Zestimate:', zestimate);


### PR DESCRIPTION
Hi,

As [mentioned on discord](https://discord.com/channels/937901803608096828/1027831756545609789/1276194217563263027) it seems like the builtin getAccountBalance method misses transactions made today, and comes back with wrong results. I've patched everything to use the builtin api.getAccountBalance().