### PR TITLE
Support multiple commas in zestimate

### DIFF
--- a/zestimate.js
+++ b/zestimate.js
@@ -25,7 +25,7 @@ async function getZestimate(URL) {
     const dom = new jsdom.JSDOM(html);
 
     const zestimateText = dom.window.document.getElementById('home-details-home-values').getElementsByTagName('h3')[0].textContent;
-    return parseInt(zestimateText.replace('$', '').replace(',', '')) * 100;
+    return parseInt(zestimateText.replace('$', '').replaceAll(',', '')) * 100;
   } catch (error) {
     console.log('Error parsing Zillow page:');
     console.log(error);


### PR DESCRIPTION
I was playing with zestimate with a property over a million dollars and the adjustments didn't work.  The second comma and the digit after it got swallowed and changed the price.  Simple tweak to catch all the commas.