### PR TITLE
fix: only parse kbb daily mileage transaction if it has previous data

### DIFF
--- a/kbb.js
+++ b/kbb.js
@@ -63,21 +63,23 @@ async function getKBB(URL) {
           const daily = parseInt(getTagValue(note, 'kbbDailyMileage'));
           if (mileage && daily) {
             let lastDate = await getLastTransactionDate(account, undefined, true);
-            const parts = lastDate.split('-');
-            lastDate = new Date(parts[0], parts[1] - 1, parts[2]);
-            if (lastDate < new Date()) {
-              let today = new Date();
-              today = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-              const days = Math.round((today - lastDate) / (1000 * 60 * 60 * 24));
-              if (days > 0) {
-                mileage += days * daily;
-
-                const newNote = note.replace(/kbbMileage:\d+/, `kbbMileage:${mileage}`);
-                await setAccountNote(account, newNote);
-
-                console.log('daily mileage:', daily);
-                console.log('days since last update:', days);
-                console.log('Updated mileage to:', mileage);
+            if (lastDate) {
+              const parts = lastDate.split('-');
+              lastDate = new Date(parts[0], parts[1] - 1, parts[2]);
+              if (lastDate < new Date()) {
+                let today = new Date();
+                today = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+                const days = Math.round((today - lastDate) / (1000 * 60 * 60 * 24));
+                if (days > 0) {
+                  mileage += days * daily;
+  
+                  const newNote = note.replace(/kbbMileage:\d+/, `kbbMileage:${mileage}`);
+                  await setAccountNote(account, newNote);
+  
+                  console.log('daily mileage:', daily);
+                  console.log('days since last update:', days);
+                  console.log('Updated mileage to:', mileage);
+                }
               }
             }
           }


### PR DESCRIPTION
# Description
This PR is to ensure that we don't try to parse `undefined`. It adds a check to ensure that the value from `getLastTransactionDate` is truthy before trying to do anything with it.

### Context

When I was setting this up for the first time, I added `kbbDailyMileage` to the new kbb account notes. This was with a fresh account with no transactions. The first time I ran the script, it ran into this error:
```bash
Unhandled Rejection at: Promise Promise {
  <rejected> TypeError: Cannot read properties of undefined (reading 'split')
      at /usr/src/app/kbb.js:66:36
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
} reason: TypeError: Cannot read properties of undefined (reading 'split')
    at /usr/src/app/kbb.js:66:36
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
TypeError: Cannot read properties of undefined (reading 'split')
    at /usr/src/app/kbb.js:66:36
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```
![Screenshot 2024-12-14 013743](https://github.com/user-attachments/assets/2a951598-fed0-4194-8b02-2311975d9dc6)

This was because we entered into this `if` because I added both current and daily mileage. But `getLastTransactionDate` was returning `undefined` because it couldn't find anything in that (empty) account.

Once I removed the `kbbDailyMileage` from the account notes and ran it again, it worked fine because it didn't enter that `if` statement. It then was able to continue and wrote the new (and first) transaction.

Once I had that first transaction in the account, I was able to add `kbbDailyMileage` back in, and the script ran normally.
