### PR TITLE
Loan Interest alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ need to edit the account notes and add the following tags:
 
 As an example, if your loan is at 4.5% interest and you want to insert an
 interest transaction on the 28th of the month, set the account note to
-`interestRate:0.045 interestDay:28`.
+`interestRate:0.045 interestDay:28 `.
 
 You can optionally change the payee used for the interest transactions by
 setting `INTEREST_PAYEE_NAME` in the `.env` file.
@@ -173,6 +173,15 @@ To run:
 ```console
 node apply-interest.js
 ```
+
+If your bank uses an "actual/actual" calculation, taking the number of days 
+in the month into account, run the alternative version.  All option above 
+apply the same. 
+
+```console
+node apply-aa-interest.js
+```
+
 
 It is recommended to run this script once per month.
 

--- a/apply-aa-interest.js
+++ b/apply-aa-interest.js
@@ -1,0 +1,74 @@
+const api = require('@actual-app/api');
+const { closeBudget, ensurePayee, getAccountBalance, getAccountNote, getLastTransactionDate, openBudget, showPercent, getTagValue } = require('./utils');
+require("dotenv").config();
+
+function daysInYear(year) {
+  // Check if the year is a leap year
+  return ((year % 4 === 0 && year % 100 > 0) || year %400 == 0) ? 366 : 365;
+}
+
+(async () => {
+  await openBudget();
+
+  const payeeId = await ensurePayee(process.env.INTEREST_PAYEE_NAME || 'Loan Interest');
+
+  const accounts = await api.getAccounts();
+  for (const account of accounts) {
+    if (account.closed) {
+      continue;
+    }
+
+    const note = await getAccountNote(account);
+
+    if (note) {
+      if (note.indexOf('interestRate:') > -1 && note.indexOf('interestDay:') > -1) {
+        let interestRate = parseFloat(getTagValue(note, 'interestRate'));
+        const interestDay = getTagValue(note, 'interestDay');
+
+        const interestTransactionDate = new Date();
+        if (interestTransactionDate.getDate() < interestDay) {
+          interestTransactionDate.setMonth(interestTransactionDate.getMonth() - 1);
+        }
+        interestTransactionDate.setDate(interestDay);
+        interestTransactionDate.setHours(5, 0, 0, 0);
+
+        const cutoff = new Date(interestTransactionDate);
+        cutoff.setMonth(cutoff.getMonth() - 1);
+        cutoff.setDate(cutoff.getDate() + 1);
+
+        const lastDate = await getLastTransactionDate(account, cutoff);
+        
+        //default to cuttoff date incase no transactions found
+        let daysPassed = Math.floor((interestTransactionDate - new Date(cutoff)) / 86400000); //86400000ms in a day
+        if (lastDate) {
+          daysPassed = Math.floor((interestTransactionDate - new Date(lastDate)) / 86400000);
+        }
+
+        const daiylInterestRate = interestRate / daysInYear(interestTransactionDate.getFullYear());
+
+        const balance = await getAccountBalance(account, interestTransactionDate);
+        const compoundedInterest = Math.round(balance * (Math.pow(1 + (daiylInterestRate * daysPassed), 1) - 1) );
+
+        interestRate = showPercent(interestRate, 3);
+
+        console.log(`== ${account.name} ==`);
+        console.log(` -> Balance:  ${balance}`);
+        console.log(`      as of ${lastDate}`);
+        console.log(` -> # days:   ${daysPassed}`);
+        console.log(` -> Interest: ${compoundedInterest} (${interestRate})`)
+
+        if (compoundedInterest) {
+          await api.importTransactions(account.id, [{
+            date: interestTransactionDate,
+            payee: payeeId,
+            amount: compoundedInterest,
+            cleared: true,
+            notes: `Interest for 1 month at ${interestRate}`,
+          }]);
+        }
+      }
+    }
+  }
+
+  await closeBudget();
+})();

--- a/utils.js
+++ b/utils.js
@@ -198,9 +198,9 @@ const Utils = {
     });
   },  
 
-  showPercent: function (pct) {
+  showPercent: function (pct, places=2) {
     return Number(pct).toLocaleString(undefined,
-        { style: 'percent', maximumFractionDigits: 2 })
+        { style: 'percent', maximumFractionDigits: places })
   },
 };
 


### PR DESCRIPTION
This adds an alternative script that applies interest using the "actual/actual" formula that some banks use for mortgages.

it may be possible to integrate this into the main script, but that's more than I want to figure out right now.

Also adds an option to display 3 decimals on the percentage formatting.