### PR TITLE
feat: Build multi-architecture Docker images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,9 @@ jobs:
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Build and push the Docker image
         id: push
         uses: docker/build-push-action@v6
@@ -52,3 +55,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Updates the GitHub Actions workflow to build Docker images for both amd64 and arm64 architectures.

This is achieved by:
- Adding a QEMU setup step (`docker/setup-qemu-action@v3`).
- Specifying `linux/amd64,linux/arm64` in the `platforms` input of the `docker/build-push-action@v6` step.