### PR TITLE
Refactor: Update Dockerfile to Node.js Alpine base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apk add --no-cache \
         xdg-utils \
         wget \
         unzip \
-        chromium \
-        chromium-chromedriver
+        chromium=136.0.7103.113-r0 \
+        chromium-chromedriver=136.0.7103.113-r0
 
 # Set the working directory in the container
 WORKDIR /usr/src/app


### PR DESCRIPTION
I've switched the base image from node:22 to node:22-alpine to reduce image size.

Key changes include:
- Updated FROM instruction to node:22-alpine.
- Replaced apt-get with apk for package management.
- Updated package names to their Alpine equivalents (e.g., libasound2 to alsa-lib, libgtk-4-1 to gtk+3.0).
- Modified Chrome and Chromedriver installation to use Alpine's `chromium` and `chromium-chromedriver` packages instead of manual downloads.
- Ensured correct user, working directory permissions, and order of operations, particularly for directory creation and ownership before switching to the 'node' user.