### PR TITLE
If using the env variable for simplefin credentials, fix method immediately returning

### DIFF
--- a/track-investments.js
+++ b/track-investments.js
@@ -6,11 +6,7 @@ require("dotenv").config();
 
 
 const getCredentials = async () => {
-  if (process.env.SIMPLEFIN_CREDENTIALS) {
-    return process.env.SIMPLEFIN_CREDENTIALS;
-  }
-
-  const token = readline.question('Enter your SimpleFIN setup token: ');
+  const token = process.env.SIMPLEFIN_CREDENTIALS ? process.env.SIMPLEFIN_CREDENTIALS : readline.question('Enter your SimpleFIN setup token: ');
   const url = atob(token.trim());
 
   const response = await fetch(url, { method: 'post' });


### PR DESCRIPTION
Token is used throughout the method, when retrieving it from the env variable, it just returns the token instead of proceeding to evaluate the username/password and cache it. This ensures that token is used for the same purpose whether it's from env or user input.