### PR TITLE
Change date filter to use $lte instead of $lt

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -46,7 +46,7 @@ const Utils = {
       api.q('transactions')
       .filter({
         'account': account.id,
-        'date': { $lt: cutoffDate },
+        'date': { $lte: cutoffDate },
       })
       .calculate({ $sum: '$amount' })
       .options({ splits: 'grouped' })


### PR DESCRIPTION
Allow for full account balance summation. Otherwise transactions from the same day as cutoff are not included.