### PR TITLE
Backup.js - Script to allow automated backup of actual budget files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,3 +407,17 @@ node sync-bitcoin.js
 ```
 
 It is recommended to run this script once per day or week.
+
+### Backup
+
+This script zips the downloaded budget and saves it in the same format as the gui would.
+This does require that the ./app folder be available, if running in docker set your volume with
+
+```
+-v ./app:/path/to/your/backup/folder
+```
+
+This does not move the backups off the device, other scripts or systems must be used to move these backups
+into more secure locations.
+
+These backups can be restored into actual using the "Import from File" option.

--- a/README.md
+++ b/README.md
@@ -32,44 +32,52 @@ Create a `.env` file in the root directory with the following content (or you
 can copy the `example.env` file):
 
 ```python
-ACTUAL_SERVER_URL="https://<Actual Budget server URL>"
-ACTUAL_SERVER_PASSWORD="<Actual Budget server password>"
-ACTUAL_SYNC_ID="<Actual Budget sync ID>"
+ACTUAL_SERVER_URL=https://samary.synology.me:5001
+ACTUAL_SERVER_PASSWORD=kyf9zpf4XAJ@zwx-bwf
+ACTUAL_SYNC_ID=b5c86f61-baa1-4385-a073-d4e0480c4778
+
 # allow self-signed SSL certs
-NODE_TLS_REJECT_UNAUTHORIZED=0
+NODE_TLS_REJECT_UNAUTHORIZED=1
 
 # optional, for encrypted files
-ACTUAL_FILE_PASSWORD="<file password>"
+ACTUAL_FILE_PASSWORD=<file password>
 
 # optional, if you want to use a different cache directory
-ACTUAL_CACHE_DIR="./cache"
+ACTUAL_CACHE_DIR=./cache
+
+# optional, if you want to use a different backup directory
+ACTUAL_BACKUP_DIR=./backup
+
+# optional, if you want to set the timezone to something other than UTC for the backup files. 
+# see: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+TZ=America/Vancouver
 
 # optional, name of the payee for added interest transactions
-INTEREST_PAYEE_NAME="Loan Interest"
+INTEREST_PAYEE_NAME=Loan Interest
 
 # optional, name of the payee for added interest transactions
-INVESTMENT_PAYEE_NAME="Investment"
+INVESTMENT_PAYEE_NAME=Investment
 # optional, name of the category group for added investment tracking transactions
-INVESTMENT_CATEGORY_GROUP_NAME="Income"
+INVESTMENT_CATEGORY_GROUP_NAME=Income
 # optional, name of the category for added investment tracking transactions
-INVESTMENT_CATEGORY_NAME="Investment"
+INVESTMENT_CATEGORY_NAME=Investment
 
 # optional, name of the payee for Zestimate entries
-ZESTIMATE_PAYEE_NAME="Zestimate"
+ZESTIMATE_PAYEE_NAME=Zestimate
 
 # optional, name of the payee for KBB entries
-KBB_PAYEE_NAME="KBB"
+KBB_PAYEE_NAME=KBB
 
 # optional, the URL for tracking Bitcoin prices
-BITCOIN_PRICE_URL="https://api.kraken.com/0/public/Ticker?pair=xbtusd"
+BITCOIN_PRICE_URL=https://api.kraken.com/0/public/Ticker?pair=xbtusd
 # optional, the JSON path in the response to get the Bitcoin price
-BITCOIN_PRICE_JSON_PATH="result.XXBTZUSD.c[0]"
+BITCOIN_PRICE_JSON_PATH=result.XXBTZUSD.c[0]
 # optional, name of the payee for Bitcoin entries
-BITCOIN_PAYEE_NAME="Bitcoin Price Change"
+BITCOIN_PAYEE_NAME=Bitcoin Price Change
 
 #optional, RentCast API key for fetching property data
-RENTCAST_API_KEY="<Rentcast API key>"
-RENTCAST_PAYEE_NAME="RentCast"
+RENTCAST_API_KEY=<Rentcast API key>
+RENTCAST_PAYEE_NAME=RentCast
 ```
 
 ### OIDC Auth Provider Support
@@ -410,12 +418,16 @@ It is recommended to run this script once per day or week.
 
 ### Backup
 
-This script zips the downloaded budget and saves it in the same format as the gui would.
-This does require that the ./app folder be available, if running in docker set your volume with
+This script zips the downloaded budget and saves it in the same format as using the `Export Budget` option in the client.
+This does require that the ./budget folder be available, if running in docker set your volume with
 
 ```
--v ./app:/path/to/your/backup/folder
+--volume /path/to/backups:./backup
 ```
+
+The backups will be formated `YYYY-MM-DD_[HHMMSS]_BudgetName.zip` these should be in the local timezone, if they
+are not then the local TZ environment variable is likely failing, set the TZ env variable in your .env file. See the
+example.env for more information.
 
 This does not move the backups off the device, other scripts or systems must be used to move these backups
 into more secure locations.

--- a/backup.js
+++ b/backup.js
@@ -2,14 +2,18 @@
 // Useful for running bank syncs on a daily/weekly schedule
 const { closeBudget, openBudget, exportBudget } = require('./utils');
 const api = require('@actual-app/api');
+const fs = require('fs');
+const archiver = require('archiver');
+const path = require("node:path");
 
 (async () => {
+  const cache = process.env.ACTUAL_CACHE_DIR || './cache';
+  const backup = process.env.ACTUAL_BACKUP_DIR || './backup';
+  
   await openBudget();
   await closeBudget();
   console.log("backing up...");
   try{
-    const cache = process.env.ACTUAL_CACHE_DIR || './cache';
-    const backup = process.env.ACTUAL_BACKUP_DIR || './app';
     const directory = await fs.readdirSync(cache);
 
     let sourceFolder = "";

--- a/backup.js
+++ b/backup.js
@@ -1,0 +1,59 @@
+// Script to run all bank syncs
+// Useful for running bank syncs on a daily/weekly schedule
+const { closeBudget, openBudget, exportBudget } = require('./utils');
+const api = require('@actual-app/api');
+
+(async () => {
+  await openBudget();
+  await closeBudget();
+  console.log("backing up...");
+  try{
+    const cache = process.env.ACTUAL_CACHE_DIR || './cache';
+    const backup = process.env.ACTUAL_BACKUP_DIR || './app';
+    const directory = await fs.readdirSync(cache);
+
+    let sourceFolder = "";
+    let sourceBudgetName = "";
+    for( const folder of directory){
+      const metadataPath = path.join(cache, folder, "metadata.json");
+      if(fs.existsSync(metadataPath)) {
+        const file = fs.readFileSync(metadataPath, 'utf8');
+        const jsonObj = JSON.parse(file);
+        if (jsonObj["groupId"] === process.env.ACTUAL_SYNC_ID) {
+          sourceFolder = path.join(cache, folder);
+          sourceBudgetName = jsonObj["budgetName"];
+          break;
+        }
+      }
+    }
+    const formatter = Intl.DateTimeFormat("it-IT", {
+      year: "numeric",
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    const now = new Date();
+    const dateString = now.toLocaleDateString('en-CA', { year: 'numeric', month: '2-digit', day: '2-digit' }).replaceAll("/","-");
+    const timeString = now.toLocaleTimeString("it-IT").replaceAll(":","");
+    const zipFileName = dateString + "_[" + timeString  + "]_" + sourceBudgetName + ".zip";
+    const outPath = path.join(backup, zipFileName);
+
+    console.log("📦 Zipping Budget '" + sourceBudgetName + "' in [" + sourceFolder + "] to [" + outPath + "]" );
+
+    const stream = fs.createWriteStream(outPath)
+    const archive = archiver('zip', { zlib: {level:9}});
+    archive.on('error', function(err){
+      throw err;
+    });
+    await archive.pipe(stream);
+    await archive.directory(sourceFolder, false);
+    await archive.finalize();
+
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+})();
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
 services:
   actual-helpers:
-    container_name: actual-helpers
-    image: ghcr.io/psybers/actual-helpers:latest
+    build:
+      context: ./
+      dockerfile: Dockerfile
+      network: host
     env_file: .env
     volumes:
       - ./cache:/usr/src/app/cache
+      - ./backup:/usr/src/app/backup
+    network_mode: host

--- a/example.env
+++ b/example.env
@@ -10,6 +10,9 @@ ACTUAL_FILE_PASSWORD="<file password>"
 # optional, if you want to use a different cache directory
 ACTUAL_CACHE_DIR="./cache"
 
+# optional, if you want to use a different backup directory
+ACTUAL_BACKUP_DIR="./app"
+
 # optional, name of the payee for added interest transactions
 INTEREST_PAYEE_NAME="Loan Interest"
 

--- a/example.env
+++ b/example.env
@@ -1,41 +1,45 @@
-ACTUAL_SERVER_URL="https://<Actual Budget server URL>"
-ACTUAL_SERVER_PASSWORD="<Actual Budget server password>"
-ACTUAL_SYNC_ID="<Actual Budget sync ID>"
+ACTUAL_SERVER_URL=https://<Actual Budget server URL>
+ACTUAL_SERVER_PASSWORD=<Actual Budget server password>
+ACTUAL_SYNC_ID=<Actual Budget sync ID>
 # allow self-signed SSL certs
 NODE_TLS_REJECT_UNAUTHORIZED=0
 
 # optional, for encrypted files
-ACTUAL_FILE_PASSWORD="<file password>"
+ACTUAL_FILE_PASSWORD=<file password>
 
 # optional, if you want to use a different cache directory
-ACTUAL_CACHE_DIR="./cache"
+ACTUAL_CACHE_DIR=./cache
 
 # optional, if you want to use a different backup directory
-ACTUAL_BACKUP_DIR="./app"
+ACTUAL_BACKUP_DIR=./backup
+
+# optional, if you want to set the timezone to something other than UTC for the backup files. 
+# see: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+TZ=Etc/UTC
 
 # optional, name of the payee for added interest transactions
-INTEREST_PAYEE_NAME="Loan Interest"
+INTEREST_PAYEE_NAME=Loan Interest
 
 # optional, name of the payee for added interest transactions
-INVESTMENT_PAYEE_NAME="Investment"
+INVESTMENT_PAYEE_NAME=Investment
 # optional, name of the category group for added investment tracking transactions
-INVESTMENT_CATEGORY_GROUP_NAME="Income"
+INVESTMENT_CATEGORY_GROUP_NAME=Income
 # optional, name of the category for added investment tracking transactions
-INVESTMENT_CATEGORY_NAME="Investment"
+INVESTMENT_CATEGORY_NAME=Investment
 
 # optional, name of the payee for Zestimate entries
-ZESTIMATE_PAYEE_NAME="Zestimate"
+ZESTIMATE_PAYEE_NAME=Zestimate
 
 # optional, name of the payee for KBB entries
-KBB_PAYEE_NAME="KBB"
+KBB_PAYEE_NAME=KBB
 
 # optional, the URL for tracking Bitcoin prices
-BITCOIN_PRICE_URL="https://api.kraken.com/0/public/Ticker?pair=xbtusd"
+BITCOIN_PRICE_URL=https://api.kraken.com/0/public/Ticker?pair=xbtusd
 # optional, the JSON path in the response to get the Bitcoin price
-BITCOIN_PRICE_JSON_PATH="result.XXBTZUSD.c[0]"
+BITCOIN_PRICE_JSON_PATH=result.XXBTZUSD.c[0]
 # optional, name of the payee for Bitcoin entries
-BITCOIN_PAYEE_NAME="Bitcoin Price Change"
+BITCOIN_PAYEE_NAME=Bitcoin Price Change
 
 #optional, RentCast API key for fetching property data
-RENTCAST_API_KEY="<Rentcast API key>"
-RENTCAST_PAYEE_NAME="RentCast"
+RENTCAST_API_KEY=<Rentcast API key>
+RENTCAST_PAYEE_NAME=RentCast

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dotenv": "^16.4.5",
     "jsdom": "^24.1.0",
     "readline-sync": "^1.4.10",
-    "selenium-webdriver": "^4.27.0"
+    "selenium-webdriver": "^4.27.0",
+    "archiver": "^7.0.1"
   }
 }

--- a/utils.js
+++ b/utils.js
@@ -20,7 +20,7 @@ const Utils = {
       process.exit(1);
     }
 
-    console.log("connect");
+    console.log("connect ", url);
     await api.init({ serverURL: url, password: password, dataDir: cache });
 
     console.log("open file");


### PR DESCRIPTION
This script opens the budget, then zips the contents of the cache. This is the same behavior that the client uses when the ExportBudget is pressed. This is preferable to backup solutions that copy the entire server image, since it is much smaller and doesn't require the server info to be copied.

I am less familiar with js node development since it is outside my normal field, but this system seems to work so far, and i have validated that the backups are usable.

It does require some additional configuration (binding a /backup volume) and for accurate timezones can require setting the TZ environment variable appropriately. I have put these into the example.env.

This is roughly one half of a good backup system, since it does not make an 'off-device' copy of the zip files. It also doesn't clean up old backups. Since it is usable through commandline users can do whatever they want with the created zip files. In my case I have a separate job to remove old ones. Future versions could add a set of 'keep' variables to try to cleanup old or duplicate budgets. Potentially zips could be hashed then compared and duplicates deleted.

