### PR TITLE
docs: update INVESTMENT_PAYEE_NAME comment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ENV ACTUAL_CACHE_DIR="./cache"
 # optional, name of the payee for added interest transactions
 ENV INTEREST_PAYEE_NAME="Loan Interest"
 
-# optional, name of the payee for added interest transactions
+# optional, name of the payee for added investment transactions
 ENV INVESTMENT_PAYEE_NAME="Investment"
 # optional, name of the category group for added investment tracking transactions
 ENV INVESTMENT_CATEGORY_GROUP_NAME="Income"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ ACTUAL_CACHE_DIR="./cache"
 # optional, name of the payee for added interest transactions
 INTEREST_PAYEE_NAME="Loan Interest"
 
-# optional, name of the payee for added interest transactions
+# optional, name of the payee for added investment transactions
 INVESTMENT_PAYEE_NAME="Investment"
 # optional, name of the category group for added investment tracking transactions
 INVESTMENT_CATEGORY_GROUP_NAME="Income"

--- a/example.env
+++ b/example.env
@@ -13,7 +13,7 @@ ACTUAL_CACHE_DIR="./cache"
 # optional, name of the payee for added interest transactions
 INTEREST_PAYEE_NAME="Loan Interest"
 
-# optional, name of the payee for added interest transactions
+# optional, name of the payee for added investment transactions
 INVESTMENT_PAYEE_NAME="Investment"
 # optional, name of the category group for added investment tracking transactions
 INVESTMENT_CATEGORY_GROUP_NAME="Income"


### PR DESCRIPTION
Comments where `INVESTMENT_PAYEE_NAME` is referenced erroneously state this is the name of the payee for `interest` transactions (the var above), rather than `investment` transactions.

This PR is just a small update to these comments to correct the wording.