### PR TITLE
Adding MarketCheck as a script option for tracking vehicle asset values

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a collection of useful scripts to help you manage your Actual Budget.
     - [Tracking Home Prices (RentCast's Value Estimate)](#tracking-home-prices-rentcasts-value-estimate)
     - [Tracking Home Prices (Zillow's Zestimate)](#tracking-home-prices-zillows-zestimate)
     - [Tracking Vehicle Prices (Kelley Blue Book)](#tracking-vehicle-prices-kelley-blue-book)
+    - [Tracking Vehicle Values (MarketCheck's Price Estimate)](#tracking-vehicle-values-marketchecks-price-estimate)
     - [Tracking Investment Accounts](#tracking-investment-accounts)
     - [Tracking Bitcoin Price](#tracking-bitcoin-price)
 
@@ -59,6 +60,11 @@ ZESTIMATE_PAYEE_NAME="Zestimate"
 
 # optional, name of the payee for KBB entries
 KBB_PAYEE_NAME="KBB"
+
+# optional, API Key for fetching MarketCheck vehicle value estimates
+MARKETCHECK_API_KEY="<MarketCheck API Key>"
+# optional, name of the payee for MarketCheck Price Estimate
+MARKETCHEC_PAYEE_NAME="MarketCheck"
 
 # optional, the URL for tracking Bitcoin prices
 BITCOIN_PRICE_URL="https://api.kraken.com/0/public/Ticker?pair=xbtusd"
@@ -284,7 +290,7 @@ It is recommended to run this script once per month.
 This script tracks the Kelley Blue Book value for a car or motorcycle.  It adds
 new transactions to keep the account balance equal to the latest KBB value.
 
-To use this script, first you need to use the KBB website to find the value of
+TTo use this script, first you need to use the KBB website to find the value of
 your car.  Be sure to select "Private Party" for the value.  It should show
 something like this:
 
@@ -323,6 +329,38 @@ To run:
 
 ```console
 node kbb.js
+```
+
+It is recommended to run this script once per month.  Note that you will have
+to periodically update the mileage in the account note.
+
+### Tracking Vehicle Values (MarketCheck's Price Estimate)
+
+This script tracks the MarketCheck retail and trade-in value for a vehicle. It adds new transactions to keep the account balance equal to the latest value. MarketCheck values differ from standard Kelley Blue Book estimates since they are pulled from real-time local dealership and private-party listing comps, making them highly accurate for current market conditions.
+
+To use this script, you need to create an asset account in Actual Budget and set the account note to populate the fields that MarketCheck needs to query the marketcheck_price endpoint: `vin`, `zip`, and `miles`.
+
+`vin` needs to be the standard 17-character Vehicle Identification Number. Supply the correct zip code and current mileage for a more accurate local market estimate.
+
+Example note for a vehicle garaged in the 12345 area with roughly 32,000 miles:
+```Plaintext
+marketcheckvin:XXXXXXXXXXXXXXXXX
+marketcheckzip:12345
+miles:32000
+``` 
+
+Optionally, you can also specify a trade-in margin with `marketcheckmargin` if you want your budget to reflect a conservative liquidation value (what a dealer would pay you) rather than full retail value. You do this by adding a "marketcheckmargin:0.8" tag to the account note. For example, if you want to calculate 85% of the retail price to account for dealership overhead and reconditioning, add "marketcheckmargin:0.85 to the account note. The script will then multiply the MarketCheck retail price by that percentage to track the vehicle's trade-in value.
+
+You can also optionally specify a different `marketcheckdealertype`.  `marketcheckdealertype` defaults to "franchise" for a wider review of comps and therefore a more accurate estimate.  Other options can be found at https://docs.marketcheck.com/docs/api/cars/market-insights/marketcheck-price#base-path
+
+You will need to create an account on MarketCheck's developer portal and set up a Developer tier plan. They offer up to 500 API calls per month for free, which easily covers a monthly sync. Copy your API key into the `MARKETCHECK_API_KEY` setting in the .env file.
+
+You can optionally change the payee used for the transactions by setting `MARKETCHECK_PAYEE_NAME` in the .env file.
+
+To run:
+
+```console
+node marketcheck.js
 ```
 
 It is recommended to run this script once per month.  Note that you will have

--- a/marketcheck.js
+++ b/marketcheck.js
@@ -1,0 +1,92 @@
+const api = require('@actual-app/api');
+const jsdom = require("jsdom");
+const { closeBudget, ensurePayee, getAccountBalance, getAccountNote, getTagValue, openBudget, showPercent, sleep } = require('./utils');
+require('dotenv').config();
+
+const marketcheckBaseUrl = 'https://api.marketcheck.com/';
+const marketCheckPriceApiRoute = '/v2/predict/car/us/marketcheck_price';
+const requiredQueryParams = ['miles', 'zip']
+
+async function getMarketCheckPrice(URL) {
+    console.log('MarketCheck URL:', URL);
+    const response = await fetch(URL, {
+        method: 'GET',
+        headers: {
+            'Accept': 'application/json',
+        }
+    });
+
+    return await response.json();
+}
+
+(async function () {
+    await openBudget();
+
+    const payeeId = await ensurePayee(process.env.MARKETCHECK_PAYEE_NAME || 'MarketCheck');
+
+    const accounts = await api.getAccounts();
+    for (const account of accounts) {
+        const note = await getAccountNote(account);
+
+        if (note) {
+            const apiKey = process.env.MARKETCHECK_API_KEY;
+            const vin = getTagValue(note,'marketcheckvin')
+            if (vin) {
+                const targetUrl = new URL(marketCheckPriceApiRoute, marketcheckBaseUrl);
+                targetUrl.searchParams.set('api_key', apiKey);
+                targetUrl.searchParams.set('vin', vin);
+                targetUrl.searchParams.set('zip', getTagValue(note, 'marketcheckzip'));
+                targetUrl.searchParams.set('miles', getTagValue(note, 'marketcheckmiles'));
+                targetUrl.searchParams.set('dealer_type', getTagValue(note, 'marketcheckdealertype') ?? 'franchise');
+                if(requiredQueryParams.filter(key => {
+                    if(targetUrl.searchParams.get(key) === 'undefined'){
+                        console.error(`Missing required value marketcheck${key}`);
+                        return true;
+                    }
+                    return false;
+                }).length > 0){
+                    break;
+                }
+
+                const marginTag = getTagValue(note, 'marketcheckmargin');
+                const margin = marginTag ? parseFloat(marginTag) : 0.85;
+          
+                console.log('Fetching MarketCheck price for account:', account.name);
+
+                const rc = await getMarketCheckPrice(targetUrl.toString());
+                if(rc.code === 400){
+                    console.error(rc.message.detail);
+                    break;
+                }
+                const value = rc.marketcheck_price * 100; // Convert to cents
+                if(isNaN(value)){
+                    console.error("Failure getting the marketCheck value, verify your note is correct");
+                    break;
+                }
+                const likelySalePrice = value * margin
+                const balance = await getAccountBalance(account);
+                const diff = likelySalePrice - balance;
+    
+                console.log('MarketCheck Value:', value);
+                console.log('Adjustment for profit margin:', value * margin);
+                console.log('Balance:', balance);
+                console.log('Difference:', diff);
+                
+                if (diff != 0) {
+                    await api.importTransactions(account.id, [{
+                        date: new Date(),
+                        payee: payeeId,
+                        amount: diff,
+                        cleared: true,
+                        reconciled: true,
+                        notes: `Update Value to ${likelySalePrice / 100} (${value / 100}*${showPercent(margin)})`,
+                    }]);
+                }
+                
+                await sleep(200); // 1/4 the "20 per second" rate limit, just to be safe
+            }
+        }
+    }
+
+  await closeBudget();
+}) ();

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
     "": {
       "dependencies": {
         "@actual-app/api": "latest",
-        "better-sqlite3": "^11.7.2",
         "chromedriver": "^131.0.4",
         "dotenv": "^16.4.5",
         "jsdom": "^24.1.0",
@@ -15,19 +14,32 @@
       }
     },
     "node_modules/@actual-app/api": {
-      "version": "25.6.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-25.6.1.tgz",
-      "integrity": "sha512-48tElHltAea8KXkMKQWtQzFAHm+4NMcOrR9W0SZDVqtIc6JMIs/uTfdgtRwN4lFl4hgx3YF5SAOJdeswrhiuCw==",
+      "version": "26.2.1",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.2.1.tgz",
+      "integrity": "sha512-oTgtVm0rhJBrDasCOAtgNxyFWoTyiQGGeaDYNIAgTq9uHJtUp7z7knA24ktFrMxEf3Jc92M0U393qnbrYTrv8g==",
       "license": "MIT",
       "dependencies": {
         "@actual-app/crdt": "^2.1.0",
-        "better-sqlite3": "^11.10.0",
+        "better-sqlite3": "^12.5.0",
         "compare-versions": "^6.1.1",
         "node-fetch": "^3.3.2",
-        "uuid": "^9.0.1"
+        "uuid": "^13.0.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@actual-app/api/node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@actual-app/crdt": {
@@ -230,13 +242,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -261,23 +273,26 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
+      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
     "node_modules/bindings": {
@@ -530,9 +545,9 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -750,9 +765,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -770,9 +785,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -1250,9 +1265,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.75.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
-      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -1374,6 +1389,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.0",
@@ -1574,9 +1590,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1715,9 +1731,9 @@
       "license": "MIT"
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -1790,9 +1806,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/utils.js
+++ b/utils.js
@@ -46,7 +46,7 @@ const Utils = {
       api.q('transactions')
       .filter({
         'account': account.id,
-        'date': { $lt: cutoffDate },
+        'date': { $lte: cutoffDate },
       })
       .calculate({ $sum: '$amount' })
       .options({ splits: 'grouped' })


### PR DESCRIPTION
Since KBB can be very aggressive with bot protections and preventing web scraping I found that MarketCheck has a free API tier with a similar pricing API route.  This added a script and the necessary documentation to leverage that API similar to how RentCast was being done.

I also updated packages due to multiple high vulns and a critical vuln.

In addition I updated the comparison for getting balance due to some weird behavior when I ran my script multiple times in a day, the balance was not pulling the updated balance, which could result in multiple transactions being created and possibly getting the wrong delta between the current balance and price estimate.