### PR TITLE
feat: Improve bank sync - run per bank, add navigator polyfill, and handle unhandled rejections

### DIFF
--- a/sync-banks.js
+++ b/sync-banks.js
@@ -7,7 +7,26 @@ const api = require('@actual-app/api');
   await openBudget();
 
   console.log("syncing banks...");
-  await api.runBankSync();
+  const accounts = await api.getAccounts();
+  const errors = [];
+
+  for (const account of accounts) {
+    try {
+      console.log(`syncing account: ${account.name}...`);
+      await api.runBankSync({ accountId: account.id });
+      console.log(`  ✓ ${account.name} synced successfully`);
+    } catch (err) {
+      console.error(`  ✗ ${account.name} failed: ${err.message}`);
+      errors.push({ account: account.name, error: err.message });
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(`\n${errors.length} account(s) failed to sync:`);
+    errors.forEach(e => console.error(`  - ${e.account}: ${e.error}`));
+  } else {
+    console.log("\nall accounts synced successfully!");
+  }
 
   await closeBudget();
 })();

--- a/utils.js
+++ b/utils.js
@@ -1,3 +1,9 @@
+// Polyfill navigator for Node.js — @actual-app/api's bundle references
+// navigator.platform which only exists in the browser.
+if (typeof globalThis.navigator === 'undefined') {
+  globalThis.navigator = { platform: '', userAgent: '' };
+}
+
 const api = require('@actual-app/api');
 require("dotenv").config();
 
@@ -5,8 +11,10 @@ const Utils = {
   openBudget: async function () {
     process.on('unhandledRejection', (reason, p) => {
       console.error('Unhandled Rejection at: Promise', p, 'reason:', reason);
-      console.error(reason.stack);
-      process.exit(1);
+      if (reason && reason.stack) {
+        console.error(reason.stack);
+      }
+      // Don't exit — let the calling script handle errors gracefully
     });
 
     const url = process.env.ACTUAL_SERVER_URL || '';


### PR DESCRIPTION
I have a few accounts (mortgage & car loans) that require 2FA and only need syncing once a month. These accounts routinely fail during automated syncs due to stale credentials, which is expected.

The Actual Budget UI already handles this well — it syncs the healthy accounts and simply notifies you about any failures. However, when syncing via the API, a single account failure would throw an unhandled error and halt the entire process, preventing the remaining accounts from syncing.

Changes
Per-account sync — Accounts are now synced individually so that one failure doesn't block the rest.
Graceful error handling — Unhandled rejections are caught and logged instead of crashing the process.
Node.js compatibility — Added a navigator polyfill to resolve a runtime error in @actual-app/api.