### PR TITLE
Add precious metals (gold/silver) price tracker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,13 @@ ENV BITCOIN_PRICE_URL="https://api.kraken.com/0/public/Ticker?pair=xbtusd"
 ENV BITCOIN_PRICE_JSON_PATH="result.XXBTZUSD.c[0]"
 ENV BITCOIN_PAYEE_NAME="Bitcoin Price Change"
 
+# optional, for retrieving precious metals prices (these default to gold-api.com USD/troy oz)
+ENV GOLD_PRICE_URL="https://api.gold-api.com/price/XAU"
+ENV GOLD_PRICE_JSON_PATH="price"
+ENV SILVER_PRICE_URL="https://api.gold-api.com/price/XAG"
+ENV SILVER_PRICE_JSON_PATH="price"
+ENV METALS_PAYEE_NAME="Metals Price Change"
+
 #optional, RentCast API key for fetching property data
 ENV RENTCAST_API_KEY=""
 ENV RENTCAST_PAYEE_NAME="RentCast"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This is a collection of useful scripts to help you manage your Actual Budget.
     - [Tracking Vehicle Prices (Kelley Blue Book)](#tracking-vehicle-prices-kelley-blue-book)
     - [Tracking Investment Accounts](#tracking-investment-accounts)
     - [Tracking Bitcoin Price](#tracking-bitcoin-price)
+    - [Tracking Crypto Prices](#tracking-crypto-prices)
+    - [Tracking Precious Metals (Gold & Silver)](#tracking-precious-metals-gold--silver)
 
 ## Requirements
 
@@ -449,3 +451,47 @@ node sync-crypto.js
 It is recommended to run this script once per day or week. If you are retrieving
 BTC prices using this script, DO NOT run the `sync-bitcoin.js` script as well, as it will
 set the account balance to the value of your BTC holdings only.
+
+### Tracking Precious Metals (Gold & Silver)
+
+This script tracks the value of physical gold and silver holdings. Similar to
+the Bitcoin and Crypto scripts, it adds new transactions to keep the account
+balance equal to the latest market value.
+
+To use, set one or both of these tags in the account notes, where the value is
+the quantity in **troy ounces** that you own:
+
+- `GOLD:X` - troy ounces of gold (e.g. `GOLD:2.5`)
+- `SILVER:X` - troy ounces of silver (e.g. `SILVER:50`)
+
+Both tags may be set on the same account; the script will sum their values into
+a single correcting transaction. Accounts without either tag are skipped.
+
+For example, an account holding 1 oz of gold and 100 oz of silver would have
+this account note:
+
+```
+GOLD:1
+SILVER:100
+```
+
+Spot prices are retrieved from [gold-api.com](https://gold-api.com/) by default
+(USD per troy ounce, no API key required). To use a different price source,
+override the URL and JSON path per metal in your `.env` file. For example, to
+fetch gold in GBP from an alternate provider:
+
+```shell
+GOLD_PRICE_URL="https://example.com/api/gold/gbp"
+GOLD_PRICE_JSON_PATH="data.price"
+```
+
+You can optionally change the payee used for the transactions by setting
+`METALS_PAYEE_NAME` in the `.env` file.
+
+To run:
+
+```console
+node sync-metals.js
+```
+
+It is recommended to run this script once per day or week.

--- a/example.env
+++ b/example.env
@@ -36,3 +36,12 @@ BITCOIN_PAYEE_NAME="Bitcoin Price Change"
 #optional, RentCast API key for fetching property data
 RENTCAST_API_KEY="<Rentcast API key>"
 RENTCAST_PAYEE_NAME="RentCast"
+
+# optional, the URL/JSON path for tracking gold spot price (default: gold-api.com USD/troy oz)
+GOLD_PRICE_URL="https://api.gold-api.com/price/XAU"
+GOLD_PRICE_JSON_PATH="price"
+# optional, the URL/JSON path for tracking silver spot price (default: gold-api.com USD/troy oz)
+SILVER_PRICE_URL="https://api.gold-api.com/price/XAG"
+SILVER_PRICE_JSON_PATH="price"
+# optional, name of the payee for precious metals entries
+METALS_PAYEE_NAME="Metals Price Change"

--- a/sync-metals.js
+++ b/sync-metals.js
@@ -1,0 +1,87 @@
+const { closeBudget, openBudget, getAccountNote, getAccountBalance, getTagValue, ensurePayee } = require('./utils');
+const api = require('@actual-app/api');
+
+function getValueAtPath(obj, path) {
+    const keys = path.split('.').filter(Boolean);
+
+    return keys.reduce((acc, key) => {
+        const match = key.match(/^([^\[\]]+)(\[(\d+)\])?$/);
+
+        if (match) {
+            const property = match[1];
+            const index = match[3];
+
+            acc = acc[property];
+
+            if (index !== undefined) {
+                acc = acc[parseInt(index, 10)];
+            }
+        } else {
+            acc = acc[key];
+        }
+
+        return acc;
+    }, obj);
+}
+
+async function getMetalPrice(metal) {
+    const defaultUrl = metal === 'GOLD'
+        ? 'https://api.gold-api.com/price/XAU'
+        : 'https://api.gold-api.com/price/XAG';
+    const url = (process.env[`${metal}_PRICE_URL`] || defaultUrl).replace(/^["']|["']$/g, '');
+    const path = (process.env[`${metal}_PRICE_JSON_PATH`] || 'price').replace(/^["']|["']$/g, '');
+    try {
+        const response = await fetch(url);
+        const json = await response.json();
+        return getValueAtPath(json, path);
+    } catch (error) {
+        console.error(`Error fetching ${metal} price:`, error);
+        return undefined;
+    }
+}
+
+(async () => {
+  const goldPrice = await getMetalPrice('GOLD');
+  const silverPrice = await getMetalPrice('SILVER');
+  if (!goldPrice && !silverPrice) {
+    throw new Error("Unable to retrieve gold or silver price. Check your GOLD_PRICE_URL / GOLD_PRICE_JSON_PATH / SILVER_PRICE_URL / SILVER_PRICE_JSON_PATH environment variables");
+  }
+
+  await openBudget();
+  const payeeId = await ensurePayee(process.env.METALS_PAYEE_NAME || 'Metals Price Change');
+  const accounts = await api.getAccounts();
+  for (const account of accounts) {
+    if (account.closed) {
+      continue;
+    }
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() + 1);
+    const note = await getAccountNote(account, cutoffDate);
+
+    const goldOz = parseFloat(getTagValue(note, 'GOLD', 0.0)) || 0;
+    const silverOz = parseFloat(getTagValue(note, 'SILVER', 0.0)) || 0;
+    if (!goldOz && !silverOz) {
+      continue;
+    }
+
+    if ((goldOz && !goldPrice) || (silverOz && !silverPrice)) {
+      console.error(`Skipping ${account.name}: missing required spot price`);
+      continue;
+    }
+
+    const targetBalance = Math.round((goldOz * (goldPrice || 0) + silverOz * (silverPrice || 0)) * 100);
+    const currentBalance = await getAccountBalance(account, cutoffDate);
+    const diff = targetBalance - currentBalance;
+    if (diff != 0) {
+      await api.importTransactions(account.id, [{
+        date: new Date(),
+        payee: payeeId,
+        amount: diff,
+        cleared: true,
+        reconciled: true,
+        notes: "Updated Metals Price",
+      }])
+    }
+  }
+  await closeBudget();
+})();

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,10 @@
 const api = require('@actual-app/api');
 require("dotenv").config();
 
+function envStr(key, defaultValue = '') {
+    return (process.env[key] || defaultValue).replace(/^["']|["']$/g, '');
+}
+
 const Utils = {
   openBudget: async function () {
     process.on('unhandledRejection', (reason, p) => {
@@ -9,11 +13,11 @@ const Utils = {
       process.exit(1);
     });
 
-    const url = process.env.ACTUAL_SERVER_URL || '';
-    const password = process.env.ACTUAL_SERVER_PASSWORD || '';
-    const file_password = process.env.ACTUAL_FILE_PASSWORD || '';
-    const sync_id = process.env.ACTUAL_SYNC_ID || '';
-    const cache = process.env.ACTUAL_CACHE_DIR || './cache';
+    const url = envStr('ACTUAL_SERVER_URL');
+    const password = envStr('ACTUAL_SERVER_PASSWORD');
+    const file_password = envStr('ACTUAL_FILE_PASSWORD');
+    const sync_id = envStr('ACTUAL_SYNC_ID');
+    const cache = envStr('ACTUAL_CACHE_DIR', './cache');
 
     if (!url || !password || !sync_id) {
       console.error('Required settings for Actual not provided.');


### PR DESCRIPTION
## Summary

- Adds `sync-metals.js` to track gold and silver spot prices and reconcile account balances in Actual Budget
- Supports configurable price sources via `GOLD_PRICE_URL` / `SILVER_PRICE_URL` env vars (defaults to gold-api.com)
- Fixes env var quote-stripping so the script works correctly with both `docker exec --env-file` and `docker run --env-file`

## Test plan

- [x] Set `GOLD:` and/or `SILVER:` tags on an Actual account note with troy oz amounts
- [x] Run `docker exec --env-file .env actual-helper node sync-metals.js` and verify a reconciling transaction is created
- [x] Confirm re-running the script on the same day produces a zero-diff (no duplicate transaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)