### PR TITLE
Remove invalid relative VOLUME instruction from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,8 +74,6 @@ ENV BITCOIN_PAYEE_NAME="Bitcoin Price Change"
 ENV RENTCAST_API_KEY=""
 ENV RENTCAST_PAYEE_NAME="RentCast"
 
-VOLUME ./cache
-
 # Copy the current directory contents into the container at /usr/src/app
 COPY --chown=node:node . .
 


### PR DESCRIPTION
## Problem

The Dockerfile declares `VOLUME ./cache`. `VOLUME` requires an absolute path,
but the classic builder doesn't reject relative ones, so the declaration is
baked into the image config as-is:

    $ docker image inspect ghcr.io/psybers/actual-helpers:latest \
        --format '{{json .Config.Volumes}}'
    {"./cache":{}}

At container creation Docker fabricates an anonymous volume for that declared
path. Because `cache` doesn't match the intended `/usr/src/app/cache`, it isn't
shadowed by the named volume from `docker-compose.yml`, so every container ends
up with two mounts:

    {
      "Type": "volume",
      "Name": "actual-budget_actual-helpers-cache",
      "Destination": "/usr/src/app/cache",
      "Mode": "rw"
    },
    {
      "Type": "volume",
      "Name": "83a128c96a1701697ccb48ef94508982cd1196a3f78476ca5b0db4223982419d",
      "Destination": "cache",
      "Mode": ""
    }

This has two effects.

**Automated image updates fail.** Any tool that recreates a container by
carrying its existing mounts forward as `source:destination` strings — Dockhand,
Watchtower, and similar — hits a parse error, because the relative destination
isn't a valid mount spec:

    invalid volume specification:
    '83a128c96a1701697ccb48ef94508982cd1196a3f78476ca5b0db4223982419d:cache':
    invalid mount config for type "volume": invalid mount path

The pull succeeds and the container recreation then fails, so the update has to
be finished by hand every time. `docker compose up -d` is unaffected, since
Compose builds the mount spec from the service definition rather than from the
previous container.

**Orphaned volumes accumulate.** Each recreation leaves another dangling
anonymous volume behind.

## Fix

Remove the instruction. `docker-compose.yml` already mounts a named volume at
`/usr/src/app/cache`, and the default `ACTUAL_CACHE_DIR=./cache` resolves
against `WORKDIR /usr/src/app` to that same path — so the declaration provides
nothing that the compose file doesn't already handle, while breaking container
recreation for everyone using an automated updater.

If you'd prefer to keep an explicit declaration, changing it to
`VOLUME /usr/src/app/cache` also fixes the invalid-path problem: the absolute
path matches the compose named volume and is shadowed by it, so no anonymous
volume is created. I've proposed removal because `VOLUME` in an image is
generally considered an anti-pattern for exactly this class of surprise, but
happy to switch to the absolute form if you'd rather.

## Testing

- Built locally; `Config.Volumes` is now `null` (was `{"./cache":{}}`).
- `docker run` produces a container with `Mounts: []` — no anonymous volume
  created, and `/cache` no longer exists in the container filesystem at all.
- `docker compose up -d` still mounts the named volume at `/usr/src/app/cache`;
  cache contents persist across `down`/`up`.
